### PR TITLE
Run Anki as the main process in the container

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -14,4 +14,4 @@ else
     fi
 fi
 
-anki -b /data
+exec anki -b /data


### PR DESCRIPTION
## What does this PR do?

The Dockerfile on this project sets `startup.sh` as its entrypoint: https://github.com/ThisIsntTheWay/headless-anki/blob/11c516e29cdb96ca6802decaf5debdbb45508908/Dockerfile#L63

However, the `anki` command is executed as a child of the shell instead of replacing the shell, which makes it difficult for it to handle signals.

This PR uses [`exec`](https://ss64.com/bash/exec.html) to replace the shell.

## Motivation

This allows for signals sent to the container to reach the `anki` process instead of being ignored by the bash shell. This is the recommended solution by, for example, [this article](https://hynek.me/articles/docker-signals/).

This is useful for this project since:
1. [`docker stop`](https://docs.docker.com/reference/cli/docker/container/stop/) and other utilities from container orchestrators typically use `SIGTERM` to stop containers gracefully.
2. Anki has [a signal handler](https://github.com/ankitects/anki/blob/1822a7c76c6751575144bbb0996a07006080da24/qt/aqt/main.py#L983) when receiving `SIGTERM` that is useful for, for example, persisting configuration settings in disk.

So, in a nutshell, the main benefit is that this allows for clean shutdown of Anki via the usual means for shutting down a container.

