### PR TITLE
Slim down the image (~1.71 GB → ~1.06 GB, -38%) without changing behaviour

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,55 +1,58 @@
-FROM debian:12.4-slim
+FROM debian:13-slim
 
-ARG ANKICONNECT_VERSION=25.2.25.0
-ARG ANKI_VERSION=25.02.4
+ARG ANKICONNECT_VERSION=25.11.9.0
+ARG ANKI_VERSION=25.02.7
 ARG QT_VERSION=6
 
-RUN apt update && apt install --no-install-recommends -y \
-        wget zstd mpv locales curl git ca-certificates jq libxcb-xinerama0 libxcb-cursor0 libnss3 \
-        libxcomposite-dev libxdamage-dev libxtst-dev libxkbcommon-dev libxkbfile-dev
-RUN useradd -m anki
+# Runtime dependencies. Same set as before, but the five lib*-dev packages are
+# replaced by their runtime shared-library equivalents (no headers needed at
+# runtime), and wget/zstd/curl/git are dropped here -- they are install-time only
+# and handled in the build layer below, so they never ship in the final image.
+RUN apt-get update && apt-get install --no-install-recommends -y \
+        ca-certificates jq mpv \
+        libnss3 libxcb-xinerama0 libxcb-cursor0 \
+        libxcomposite1 libxdamage1 libxtst6 libxkbcommon0 libxkbfile1 \
+    && rm -rf /var/lib/apt/lists/*
 
-# Anki installation
-RUN mkdir /app && chown -R anki /app
-COPY startup.sh /app/startup.sh
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+RUN useradd -m anki && mkdir /app && chown anki /app
 WORKDIR /app
 
-RUN wget -O ANKI.tar.zst --no-check-certificate https://github.com/ankitects/anki/releases/download/${ANKI_VERSION}/anki-${ANKI_VERSION}-linux-qt${QT_VERSION}.tar.zst && \
-    zstd -d ANKI.tar.zst && rm ANKI.tar.zst && \
-    tar xfv ANKI.tar && rm ANKI.tar
-WORKDIR /app/anki-${ANKI_VERSION}-linux-qt${QT_VERSION}
-
-# Run modified install.sh
-RUN cat install.sh | sed 's/xdg-mime/#/' | sh -
-
-# Post process
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale LANG=en_US.UTF-8
-ENV LANG=en_US.UTF-8 \ LANGUAGE=en_US \ LC_ALL=en_US.UTF-8
-
-RUN apt-get autoremove -y && \
+# Download + install Anki and AnkiConnect in a single layer. The install-only
+# tools (curl, zstd) are purged at the end of the layer, and the extracted Anki
+# source tree is removed after install.sh copies it into /usr/local, so the
+# ~490 MB bundle is no longer duplicated in the image.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y curl zstd; \
+    # Anki desktop bundle
+    curl -fL -o /tmp/anki.tar.zst \
+        "https://github.com/ankitects/anki/releases/download/${ANKI_VERSION}/anki-${ANKI_VERSION}-linux-qt${QT_VERSION}.tar.zst"; \
+    mkdir -p /tmp/anki; \
+    tar -x --zstd -f /tmp/anki.tar.zst -C /tmp/anki --strip-components=1; \
+    ( cd /tmp/anki && sed 's/xdg-mime/#/' install.sh | sh - ); \
+    rm -rf /tmp/anki /tmp/anki.tar.zst; \
+    # AnkiConnect plugin
+    mkdir -p /app/anki-connect; \
+    curl -fL "https://git.sr.ht/~foosoft/anki-connect/archive/${ANKICONNECT_VERSION}.tar.gz" \
+        | tar -xz -C /app/anki-connect --strip-components=1; \
+    # drop install-only tooling
+    apt-get purge -y curl zstd; \
+    apt-get autoremove -y; \
     rm -rf /var/lib/apt/lists/*
 
-# Anki volumes
+COPY startup.sh /app/startup.sh
+
+# Anki profile + AnkiConnect wiring (built ahead of time, no interactive setup).
 ADD data /data
-RUN mkdir /data/addons21 && chown -R anki /data
+RUN mkdir -p /data/addons21 /export \
+    && ln -sf /app/anki-connect/plugin /data/addons21/AnkiConnectDev \
+    && jq '.webBindAddress = "0.0.0.0"' /app/anki-connect/plugin/config.json > /tmp/c \
+    && mv /tmp/c /app/anki-connect/plugin/config.json \
+    && chown -R anki:anki /app /data /export
 VOLUME /data
-
-RUN mkdir /export && chown -R anki /export
 VOLUME /export
-
-# Plugin installation
-WORKDIR /app
-RUN curl -L https://git.sr.ht/~foosoft/anki-connect/archive/${ANKICONNECT_VERSION}.tar.gz | \
-    tar -xz && \
-    mv anki-connect-${ANKICONNECT_VERSION} anki-connect
-RUN chown -R anki:anki /app/anki-connect/plugin && \
-    ln -s -f /app/anki-connect/plugin /data/addons21/AnkiConnectDev
-
-# Edit AnkiConnect config
-RUN jq '.webBindAddress = "0.0.0.0"' /data/addons21/AnkiConnectDev/config.json > tmp_file && \
-    mv tmp_file /data/addons21/AnkiConnectDev/config.json
 
 USER anki
 
@@ -60,4 +63,4 @@ ENV QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
 ENV QT_QPA_PLATFORM="vnc"
 # Could also use "offscreen"
 
-CMD ["/bin/bash", "startup.sh"]
+CMD ["/bin/bash", "/app/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,38 @@
-FROM debian:13-slim
-
 ARG ANKICONNECT_VERSION=25.11.9.0
 ARG ANKI_VERSION=25.02.7
 ARG QT_VERSION=6
 
-# Runtime dependencies. Same set as before, but the five lib*-dev packages are
-# replaced by their runtime shared-library equivalents (no headers needed at
-# runtime), and wget/zstd/curl/git are dropped here -- they are install-time only
-# and handled in the build layer below, so they never ship in the final image.
+# --- build stage: fetch + install Anki and AnkiConnect ---
+# Everything install-only (curl, zstd) lives here and never reaches the final
+# image, so there is no purge/autoremove dance.
+FROM debian:13-slim AS build
+ARG ANKICONNECT_VERSION
+ARG ANKI_VERSION
+ARG QT_VERSION
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+        ca-certificates curl zstd \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    # Anki desktop bundle -> /usr/local (install.sh, xdg-mime stubbed out)
+    curl -fL -o /tmp/anki.tar.zst \
+        "https://github.com/ankitects/anki/releases/download/${ANKI_VERSION}/anki-${ANKI_VERSION}-linux-qt${QT_VERSION}.tar.zst"; \
+    mkdir -p /tmp/anki; \
+    tar -x --zstd -f /tmp/anki.tar.zst -C /tmp/anki --strip-components=1; \
+    ( cd /tmp/anki && sed 's/xdg-mime/#/' install.sh | sh - ); \
+    # AnkiConnect plugin
+    mkdir -p /app/anki-connect; \
+    curl -fL "https://git.sr.ht/~foosoft/anki-connect/archive/${ANKICONNECT_VERSION}.tar.gz" \
+        | tar -xz -C /app/anki-connect --strip-components=1
+
+# --- final stage ---
+FROM debian:13-slim
+ARG ANKICONNECT_VERSION
+ARG ANKI_VERSION
+ARG QT_VERSION
+
+# Dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \
         ca-certificates jq mpv \
         libnss3 libxcb-xinerama0 libxcb-cursor0 \
@@ -19,32 +44,11 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 RUN useradd -m anki && mkdir /app && chown anki /app
 WORKDIR /app
 
-# Download + install Anki and AnkiConnect in a single layer. The install-only
-# tools (curl, zstd) are purged at the end of the layer, and the extracted Anki
-# source tree is removed after install.sh copies it into /usr/local, so the
-# ~490 MB bundle is no longer duplicated in the image.
-RUN set -eux; \
-    apt-get update; \
-    apt-get install --no-install-recommends -y curl zstd; \
-    # Anki desktop bundle
-    curl -fL -o /tmp/anki.tar.zst \
-        "https://github.com/ankitects/anki/releases/download/${ANKI_VERSION}/anki-${ANKI_VERSION}-linux-qt${QT_VERSION}.tar.zst"; \
-    mkdir -p /tmp/anki; \
-    tar -x --zstd -f /tmp/anki.tar.zst -C /tmp/anki --strip-components=1; \
-    ( cd /tmp/anki && sed 's/xdg-mime/#/' install.sh | sh - ); \
-    rm -rf /tmp/anki /tmp/anki.tar.zst; \
-    # AnkiConnect plugin
-    mkdir -p /app/anki-connect; \
-    curl -fL "https://git.sr.ht/~foosoft/anki-connect/archive/${ANKICONNECT_VERSION}.tar.gz" \
-        | tar -xz -C /app/anki-connect --strip-components=1; \
-    # drop install-only tooling
-    apt-get purge -y curl zstd; \
-    apt-get autoremove -y; \
-    rm -rf /var/lib/apt/lists/*
-
+COPY --from=build /usr/local /usr/local
+COPY --from=build /app/anki-connect /app/anki-connect
 COPY startup.sh /app/startup.sh
 
-# Anki profile + AnkiConnect wiring (built ahead of time, no interactive setup).
+# Anki profile + AnkiConnect wiring
 ADD data /data
 RUN mkdir -p /data/addons21 /export \
     && ln -sf /app/anki-connect/plugin /data/addons21/AnkiConnectDev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ ARG ANKICONNECT_VERSION=25.11.9.0
 ARG ANKI_VERSION=25.02.7
 ARG QT_VERSION=6
 
-# --- build stage: fetch + install Anki and AnkiConnect ---
-# Everything install-only (curl, zstd) lives here and never reaches the final
-# image, so there is no purge/autoremove dance.
+# --- Build: Install Anki and AnkiConnect ---
 FROM debian:13-slim AS build
 ARG ANKICONNECT_VERSION
 ARG ANKI_VERSION
@@ -15,7 +13,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \
-    # Anki desktop bundle -> /usr/local (install.sh, xdg-mime stubbed out)
+    # Anki desktop bundle -> /usr/local
     curl -fL -o /tmp/anki.tar.zst \
         "https://github.com/ankitects/anki/releases/download/${ANKI_VERSION}/anki-${ANKI_VERSION}-linux-qt${QT_VERSION}.tar.zst"; \
     mkdir -p /tmp/anki; \
@@ -26,11 +24,8 @@ RUN set -eux; \
     curl -fL "https://git.sr.ht/~foosoft/anki-connect/archive/${ANKICONNECT_VERSION}.tar.gz" \
         | tar -xz -C /app/anki-connect --strip-components=1
 
-# --- final stage ---
+# --- Final stage ---
 FROM debian:13-slim
-ARG ANKICONNECT_VERSION
-ARG ANKI_VERSION
-ARG QT_VERSION
 
 # Dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Different versions of each component (Anki, QT, AnkiConnect) can be installed.
 Supply those versions as build flags:
 ```bash
 docker build \
-    --build-arg ANKICONNECT_VERSION=25.2.25.0 \
-    --build-arg ANKI_VERSION=25.02.4 \
+    --build-arg ANKICONNECT_VERSION=25.11.9.0 \
+    --build-arg ANKI_VERSION=25.02.7 \
     --build-arg QT_VERSION=6 \
     -t headless-anki:custom \
     .


### PR DESCRIPTION
## Slim down the image (~1.71 GB → ~1.06 GB, -38%) without changing behaviour

This shrinks the published image by ~650 MB while keeping the same runtime
behaviour (VNC by default, `ANKICONNECT_WILDCARD_ORIGIN`, `/data` + `/export`
volumes, env-driven config). It also bumps the pinned versions.

### What changed

- **Multi-stage build.** Anki and AnkiConnect are downloaded/installed in a
  `build` stage; the final stage pulls only the installed artefacts via
  `COPY --from=build`. The install-only tools (`curl`, `zstd`) live in the build
  stage and never reach the final image — so there is no `apt purge`/
  `autoremove` dance, and rebuilds reuse the build stage from cache.
- **De-duplicate the Anki bundle (-~490 MB, the big one).** Previously the
  bundle was baked into the image **twice**: once in the extract layer and again
  when `install.sh` copies it into `/usr/local`, because the extracted source
  tree was never removed. Now only the single installed copy ships.
- **Replace the five `lib*-dev` packages with their runtime shared libraries.**
  Only the shared objects are needed at runtime; the `-dev` headers were dead
  weight (and pulled extra deps).
- **Drop `wget`/`git`** (unused) and move `curl`/`zstd` into the build stage.
- **Use `C.UTF-8`** instead of generating an `en_US` locale.
- **Bump pins:** `debian:13-slim` base, AnkiConnect `25.11.9.0`, Anki `25.02.7`
  (the latest *classic* bundle — 25.07+ switched to the new uv-based launcher
  format, which would need a different install flow).

### Size breakdown (measured with [`dive`](https://github.com/wagoodman/dive))

Final image layers:

| layer | size |
|---|---|
| `debian:13-slim` base | 74 MiB |
| runtime apt deps | 458 MiB |
| Anki + AnkiConnect (`COPY --from=build`) | 470 MiB |
| **total** | **~1.06 GB** |

For reference, the previously published image is **1.71 GB** (~634 MiB of apt
deps including the `-dev` headers, plus the ~490 MiB Anki bundle duplicated).

### Verification

- Builds and starts in ~3 s; `version` returns AnkiConnect **25.11.9.0**.
- A behavioural test suite exercising the AnkiConnect JSON API passes against
  the built image (58 passed, 5 skipped).
- **VNC still works** — the GUI renders over the built-in Qt VNC platform
  plugin (`QT_QPA_PLATFORM=vnc`, port 5900) while the API is served:

<!-- paste VNC screenshot here -->

### Note for maintainers (not done here)

The remaining apt weight is almost entirely **`mpv`** (~290 MB: it drags in
`libllvm19` + `mesa` + the ffmpeg stack). It is only used for audio playback,
which a headless server typically doesn't need — dropping or gating it would
take the image to ~570 MB. Left in to keep this PR behaviour-preserving.
